### PR TITLE
Fix Health Pickup Cleanup Bug

### DIFF
--- a/Objects/HealthPickup/health_pickup.tscn
+++ b/Objects/HealthPickup/health_pickup.tscn
@@ -2,7 +2,7 @@
 
 [ext_resource type="Script" uid="uid://baaqirjipamlk" path="res://Objects/HealthPickup/health_pickup.gd" id="1_wvjdf"]
 
-[node name="HealthPickup" type="Area2D"]
+[node name="HealthPickup" type="Area2D" groups=["HealthPickups"]]
 script = ExtResource("1_wvjdf")
 
 [node name="Polygon2D" type="Polygon2D" parent="."]

--- a/main.gd
+++ b/main.gd
@@ -131,3 +131,4 @@ func game_over():
 	
 	get_tree().call_group("Enemies", "queue_free")
 	get_tree().call_group("Pickups", "queue_free")
+	get_tree().call_group("HealthPickups", "queue_free")


### PR DESCRIPTION
- When game ended health pickups were not being cleared from the screen
- Added Health Pickups to a group and queue_freed all pickups at the end of the game